### PR TITLE
Set required versions

### DIFF
--- a/backend/query/Cargo.toml
+++ b/backend/query/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 bb8 = "0.8.0"
 bb8-diesel = { git = "https://github.com/overdrivenpotato/bb8-diesel.git" }
 chrono = { version = "0.4.23", features = ["serde"] }
-diesel-derive-newtype = { version = "2.0.0-rc.0"}
+diesel-derive-newtype = { version = "=2.0.0-rc.0" }
 diesel_migrations = { version = "2.0.0", features = ["postgres"] }
 password-hash = { version = "0.5.0", features = ["std"] }
 r2d2 = "0.8.10"
@@ -24,7 +24,7 @@ uuid = { version = "1.3.0", features = ["v4", "serde"] }
 uchat_domain = { path = "../../shared/domain", features = ["query"] }
 
 [dependencies.diesel]
-version = "2.0.3"
+version = "=2.0.3"
 features = [
   "postgres",
   "uuid",
@@ -34,7 +34,6 @@ features = [
   "postgres_backend",
 ]
 default-features = false
-optional = true
 
 [dev-dependencies]
 dotenvy = "0.15.7"

--- a/shared/domain/Cargo.toml
+++ b/shared/domain/Cargo.toml
@@ -14,13 +14,21 @@ thiserror = "1"
 uuid = { version = "1.3.0", features = ["v4", "serde", "js"] }
 
 # backend
-diesel-derive-newtype = {version = "2.0.0", optional = true}
+diesel-derive-newtype = { version = "=2.0.0-rc.0", optional = true }
 
-[dependencies.diesel]  
-version = "2.0.3"
-features = ["postgres", "uuid", "chrono", "serde_json", "postgres_backend", "i-implement-a-third-party-backend-and-opt-into-breaking-changes"]
+[dependencies.diesel]
+version = "=2.0.3"
+features = [
+  "postgres",
+  "uuid",
+  "chrono",
+  "serde_json",
+  "postgres_backend",
+  "i-implement-a-third-party-backend-and-opt-into-breaking-changes",
+]
 default-features = false
 optional = true
 
 [features]
 query = ["dep:diesel", "dep:diesel-derive-newtype"]
+


### PR DESCRIPTION
Also removed the `optional` line in the query crate. Diesel is required for that crate.